### PR TITLE
Add support for POSTBOX_READY as a response

### DIFF
--- a/examples/postbox/index.js
+++ b/examples/postbox/index.js
@@ -58,7 +58,7 @@ app.get("/send-receipt", (req, res) => {
 app.get("/push", (req, res) => {
     const { result, postboxId, publicKey, sessionKey } = req.query;
 
-    const canPush = result === "SUCCESS" && postboxId && publicKey && sessionKey;
+    const canPush = (result === "SUCCESS" || result === "POSTBOX_READY") && postboxId && publicKey && sessionKey;
 
     if (!canPush) {
         res.render("pages/error");


### PR DESCRIPTION
This commit will allow the postbox flow to continue working when a
callback is returned with a `POSTBOX_READY` on top of the expected `SUCCESS`.

This is needed because Android digi.me application currently returns
`POSTBOX_READY` on successful postbox creation. That will be changed in
future releases of the android application.

Until then, this example application will need to support both success
flags.